### PR TITLE
use production links

### DIFF
--- a/src/options/views/settings-view/settings-view.html
+++ b/src/options/views/settings-view/settings-view.html
@@ -169,8 +169,8 @@ options page when clicked
         </div>
     </div>
   </div>
-  <script src="https://unpkg.com/@popperjs/core@2/dist/umd/popper.min.js"></script>
-  <script src="https://unpkg.com/tippy.js@6/dist/tippy-bundle.umd.js"></script>
+  <script src="https://unpkg.com/@popperjs/core@2"></script>
+  <script src="https://unpkg.com/tippy.js@6"></script>
   <!-- <script src="../../../libs/dark-mode-switch-1.0.0/dark-mode-switch.min.js" ></script> -->
   <!-- For some reason, this script is not loading from here... -->
 </template>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -346,7 +346,7 @@ popup.html is the html scaffolding for OptMeowt's popup page
         </div>
       </div>
     </div>
-    <script src="https://unpkg.com/@popperjs/core@2/dist/umd/popper.min.js"></script>
-    <script src="https://unpkg.com/tippy.js@6/dist/tippy-bundle.umd.js"></script>
+    <script src="https://unpkg.com/@popperjs/core@2"></script>
+    <script src="https://unpkg.com/tippy.js@6"></script>
   </body>
 </html>


### PR DESCRIPTION
Changed  cdn links for tippy.js to production instead of developer links