### PR TITLE
add specs for js-yaml library in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -215,6 +215,7 @@
         "grunt-legacy-util": "~0.2.0",
         "hooker": "~0.2.3",
         "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
         "lodash": "~0.9.2",
         "minimatch": "~0.2.12",
         "nopt": "~1.0.10",
@@ -326,6 +327,16 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dev": true,
+      "requires": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      }
     },
     "lodash": {
       "version": "0.9.2",


### PR DESCRIPTION
add specs for js-yaml library in package-lock.json to fix grunt bug discovered in AMO manual review