### PR TITLE
Fixed bug where not all 3rd party domains were enabled

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -22,6 +22,11 @@ import {
  * @param {Object} event - contains information about the event
  */
 document.addEventListener("DOMContentLoaded", (event) => {
+  ///Send the message that the DOM has loaded to background.js to clear global_domains
+  chrome.runtime.sendMessage({
+    msg: "LOADED",
+    data: Date.now(),
+  });
   var parsed_domain = "";
 
   /**


### PR DESCRIPTION
Removed the restriction on not sending GPC with requests of type images. Made sure that ALL urls are added to the chrome domain list by keeping a local list of domains for each tab, to fix issue #109 . I created a variable called global_domains that stores all the domains for the current tab and ensures that that entire list is checked against the chrome domain list. This fixes the problem where a domain, such as google.com, would be added to the domain list via chrome.storage.set, but before it could finish uploading to the chrome storage, the chrome domain list was queried with chrome.storage.get at the top of updateDomainsAndSignal which returned a version of the domain list without the new google.com domain. When that google-less domain was itself updated with .set, it would overwrite whatever the chrome domain list was at the time of .setting, meaning that google.com didn't get permanently added to the chrome domain list. 

The global_domains variable is wiped every time a new page is loaded to ensure that a huge object isn't built up of all the domains. I was a little shaky on event implementation in JS, because when I tried to add a listener for the DOMcontentloaded event in background.js it only ran once. I used a little workaround where I used chrome.sendmessage to send LOADED in the popup.js DOMcontentloaded event, since I knew that event was being triggered, and then added a listener in background.js for that LOADED message and then wiped global_domains in the listener. This isn't 100% efficient as some domains seem to come in after the DOMcontentLoaded event, but that means that only around 5 or so domains are left in global_domains rather than hundreds, so I think it is a reasonable margin of error. 

After some testing it seems that all domains are being enabled correctly on all websites. The one thing to potentially look for is whether this process slows down page loading, as it does involve a O(n^2) for loop, but only over a single tab's requests, which usually aren't more than 100.